### PR TITLE
Update Emacs from 29.4 to 30.1 on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Emacs
         uses: purcell/setup-emacs@master
         with:
-          version: "29.4"
+          version: "30.1"
       - name: Install aspell
         run: sudo apt-get install aspell
       - name: Run test


### PR DESCRIPTION
Recently Emacs 30.1 has been released:
https://www.masteringemacs.org/article/whats-new-in-emacs-301