### PR TITLE
Use new `:vc` option of `use-package` since Emacs 30.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,4 +63,3 @@ flycheck_*.el
 /request/
 /tree-sitter/
 /multisession/
-/git-packages/

--- a/init.el
+++ b/init.el
@@ -140,16 +140,3 @@
 (setq custom-file "~/.emacs-env.el")
 (when (file-exists-p custom-file)
   (load custom-file))
-(custom-set-variables
- ;; custom-set-variables was added by Custom.
- ;; If you edit it by hand, you could mess it up, so be careful.
- ;; Your init file should contain only one such instance.
- ;; If there is more than one, they won't work right.
- '(package-vc-selected-packages
-    '((treesit-fold :url "https://github.com/emacs-tree-sitter/treesit-fold"))))
-(custom-set-faces
- ;; custom-set-faces was added by Custom.
- ;; If you edit it by hand, you could mess it up, so be careful.
- ;; Your init file should contain only one such instance.
- ;; If there is more than one, they won't work right.
- )

--- a/init.el
+++ b/init.el
@@ -62,19 +62,6 @@
   '((:eval (if (buffer-file-name) (abbreviate-file-name (buffer-file-name)) "%b"))
      " @ Emacs " emacs-version))
 
-;; Utilities
-(defun my/download-github-package (repo-url &optional branch)
-  "Download GitHub package from REPO-URL.
-If the optional BRANCH arg is specified, download the branch instead of the default one."
-  (let* ((package-name (car (last (split-string repo-url "/"))))
-          (package-dir (expand-file-name (format "git-packages/%s" package-name) user-emacs-directory)))
-    (message "Downloading '%s' to '%s' ..." repo-url package-dir)
-    (if (file-directory-p package-dir)
-      (shell-command (format "git -C '%s' pull" package-dir))
-      (if branch
-        (shell-command (format "git clone --depth=1 '%s' '%s' --branch='%s'" repo-url package-dir branch))
-        (shell-command (format "git clone --depth=1 '%s' '%s'" repo-url package-dir))))))
-
 ;; MELPA (https://github.com/melpa/melpa)
 (require 'package)
 (setq package-install-upgrade-built-in t)
@@ -90,6 +77,7 @@ If the optional BRANCH arg is specified, download the branch instead of the defa
 (eval-when-compile
   (require 'use-package)
   (setq use-package-always-ensure t)
+  (setq use-package-vc-prefer-newest t)
 
   ;; https://github.com/jwiegley/use-package#diminishing-and-delighting-minor-modes
   (use-package delight)
@@ -152,3 +140,16 @@ If the optional BRANCH arg is specified, download the branch instead of the defa
 (setq custom-file "~/.emacs-env.el")
 (when (file-exists-p custom-file)
   (load custom-file))
+(custom-set-variables
+ ;; custom-set-variables was added by Custom.
+ ;; If you edit it by hand, you could mess it up, so be careful.
+ ;; Your init file should contain only one such instance.
+ ;; If there is more than one, they won't work right.
+ '(package-vc-selected-packages
+    '((treesit-fold :url "https://github.com/emacs-tree-sitter/treesit-fold"))))
+(custom-set-faces
+ ;; custom-set-faces was added by Custom.
+ ;; If you edit it by hand, you could mess it up, so be careful.
+ ;; Your init file should contain only one such instance.
+ ;; If there is more than one, they won't work right.
+ )

--- a/inits/init-copilot.el
+++ b/inits/init-copilot.el
@@ -1,10 +1,6 @@
-(my/download-github-package "https://github.com/zerolfx/copilot.el")
-
 (use-package copilot
+  :vc (:url "https://github.com/zerolfx/copilot.el")
   :after (:all editorconfig s)
-  :load-path (lambda () "git-packages/copilot.el")
-  ;; :hook
-  ;; (emacs-lisp-mode . copilot-mode)
   :bind (:map copilot-completion-map
           ("<tab>" . 'copilot-accept-completion)
           ("TAB" . 'copilot-accept-completion)

--- a/inits/init-flymake.el
+++ b/inits/init-flymake.el
@@ -5,12 +5,10 @@
 
 (use-package flymake-eslint)
 
-(my/download-github-package "https://github.com/orzechowskid/flymake-stylelint")
 (use-package flymake-stylelint
-  :load-path (lambda () "git-packages/flymake-stylelint"))
+  :vc (:url "https://github.com/orzechowskid/flymake-stylelint"))
 
-(my/download-github-package "https://github.com/ybiquitous/flymake-hadolint")
 (use-package flymake-hadolint
-  :load-path (lambda () "git-packages/flymake-hadolint"))
+  :vc (:url "https://github.com/ybiquitous/flymake-hadolint"))
 
 (provide 'init-flymake)

--- a/inits/init-hideshow.el
+++ b/inits/init-hideshow.el
@@ -1,8 +1,7 @@
 ;; https://www.emacswiki.org/emacs/HideShow
 (use-package hideshow)
 
-(my/download-github-package "https://github.com/sheijk/hideshowvis")
 (use-package hideshowvis
-  :load-path (lambda () "git-packages/hideshowvis"))
+  :vc (:url "https://github.com/sheijk/hideshowvis"))
 
 (provide 'init-hideshow)

--- a/inits/init-ruby.el
+++ b/inits/init-ruby.el
@@ -15,8 +15,7 @@
 (use-package ruby-electric
   :hook (ruby-base-mode . ruby-electric-mode))
 
-(my/download-github-package "https://github.com/ybiquitous/rbs-mode")
 (use-package rbs-mode
-  :load-path (lambda () "git-packages/rbs-mode"))
+  :vc (:url "https://github.com/ybiquitous/rbs-mode"))
 
 (provide 'init-ruby)

--- a/inits/init-tree-sitter.el
+++ b/inits/init-tree-sitter.el
@@ -10,14 +10,11 @@
   (treesit-auto-add-to-auto-mode-alist 'all)
   (global-treesit-auto-mode))
 
-(my/download-github-package "https://github.com/emacs-tree-sitter/treesit-fold")
 (use-package treesit-fold
-  :load-path (lambda () "git-packages/treesit-fold")
+  :vc (:url "https://github.com/emacs-tree-sitter/treesit-fold")
   :delight " TS-Fold"
-  :hook ((ruby-ts-mode yaml-ts-mode) . treesit-fold-mode))
-
-(use-package treesit-fold-indicators
-  :load-path (lambda () "git-packages/treesit-fold")
-  :hook ((ruby-ts-mode yaml-ts-mode) . treesit-fold-indicators-mode))
+  :hook
+  ((ruby-ts-mode yaml-ts-mode) . treesit-fold-mode)
+  ((ruby-ts-mode yaml-ts-mode) . treesit-fold-indicators-mode))
 
 (provide 'init-tree-sitter)


### PR DESCRIPTION
This also removes the custom utility function `my/download-github-package` since it's no longer necessary.
