### PR TITLE
Configure `editorconfig` package that has been built-in since Emacs 30.1

### DIFF
--- a/inits/init-editorconfig.el
+++ b/inits/init-editorconfig.el
@@ -1,6 +1,5 @@
 (use-package editorconfig
-  :delight " EC"
   :config
-  (editorconfig-mode t))
+  (editorconfig-mode))
 
 (provide 'init-editorconfig)


### PR DESCRIPTION
`:delight` is no longer necessary because `editorconfig-mode` is now a global minor mode.